### PR TITLE
feat: add ring equality check and expose ring on ringsig

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -18,6 +18,24 @@ func (r *Ring) Size() int {
 	return len(r.pubkeys)
 }
 
+// Equals checks whether the supplied ring is equal to the current ring.
+func (ring *Ring) Equals(other *Ring) bool {
+	for i, p := range ring.pubkeys {
+		if eq := p.Equals(other.pubkeys[i]); !eq {
+			return false
+		}
+	}
+	bp, abp := ring.curve.BasePoint(), ring.curve.AltBasePoint()
+	obp, oabp := other.curve.BasePoint(), other.curve.AltBasePoint()
+	if eq := bp.Equals(obp); !eq {
+		return false
+	}
+	if eq := abp.Equals(oabp); !eq {
+		return false
+	}
+	return true
+}
+
 // RingSig represents a ring signature.
 type RingSig struct {
 	ring  *Ring          // array of public keys
@@ -33,6 +51,11 @@ func (r *RingSig) PublicKeys() []types.Point {
 		ret[i] = pk.Copy()
 	}
 	return ret
+}
+
+// Ring returns the ring from the RingSig struct
+func (r *RingSig) Ring() *Ring {
+	return r.ring
 }
 
 // NewKeyRingFromPublicKeys takes public key ring and places the public key corresponding to `privkey`

--- a/ring.go
+++ b/ring.go
@@ -19,21 +19,16 @@ func (r *Ring) Size() int {
 }
 
 // Equals checks whether the supplied ring is equal to the current ring.
+// The ring's public keys must be in the same order for the rings to be equal
 func (ring *Ring) Equals(other *Ring) bool {
 	for i, p := range ring.pubkeys {
-		if eq := p.Equals(other.pubkeys[i]); !eq {
+		if !p.Equals(other.pubkeys[i]) {
 			return false
 		}
 	}
 	bp, abp := ring.curve.BasePoint(), ring.curve.AltBasePoint()
 	obp, oabp := other.curve.BasePoint(), other.curve.AltBasePoint()
-	if eq := bp.Equals(obp); !eq {
-		return false
-	}
-	if eq := abp.Equals(oabp); !eq {
-		return false
-	}
-	return true
+	return bp.Equals(obp) && abp.Equals(oabp)
 }
 
 // RingSig represents a ring signature.

--- a/ring_test.go
+++ b/ring_test.go
@@ -108,6 +108,36 @@ func TestGenKeyRing(t *testing.T) {
 	}
 }
 
+func TestRing_Equals(t *testing.T) {
+	curve := Secp256k1()
+	privkey := curve.NewRandomScalar()
+	keyring, err := NewKeyRing(curve, 10, privkey, 0)
+	require.NoError(t, err)
+	keyring2, err := NewKeyRing(curve, 10, privkey, 0)
+	require.NoError(t, err)
+	require.False(t, keyring.Equals(keyring2)) // NewKeyRing generates random pubkeys
+	keyring3, err := NewFixedKeyRingFromPublicKeys(curve, keyring.pubkeys)
+	require.NoError(t, err)
+	require.True(t, keyring.Equals(keyring3))
+}
+
+func TestSig_RingEquals(t *testing.T) {
+	curve := Secp256k1()
+	privkey := curve.NewRandomScalar()
+	keyring, err := NewKeyRing(curve, 10, privkey, 0)
+	require.NoError(t, err)
+	keyring2, err := NewKeyRing(curve, 10, privkey, 0)
+	require.NoError(t, err)
+	sig, err := keyring.Sign(testMsg, privkey)
+	require.NoError(t, err)
+	sig2, err := keyring2.Sign(testMsg, privkey)
+	require.NoError(t, err)
+	require.False(t, sig.Ring().Equals(keyring2))
+	require.True(t, sig.Ring().Equals(keyring))
+	require.False(t, sig2.Ring().Equals(keyring))
+	require.True(t, sig2.Ring().Equals(keyring2))
+}
+
 func TestSign(t *testing.T) {
 	createSig(t, 9, 0)
 }


### PR DESCRIPTION
## Summary

This PR addresses issue #13 by adding the following methods:
```go
func (r *Ring) Equals(other *Ring) bool
func (rs *RingSig) Ring() *Ring
```

These allow for the `RingSig` to check whether it contains a specific ring using the following flow:
```go
if eq := sig.Ring().Equals(otherRing); !eq {
	panic("ring sig doesnt contain otherRing")
}
```